### PR TITLE
refactor : review dialog CSR & route handler 적용

### DIFF
--- a/app/api/reviews/[id]/route.ts
+++ b/app/api/reviews/[id]/route.ts
@@ -1,0 +1,14 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { getReviewsByMovie } from "@/app/features/review/apis";
+
+export async function GET(request: NextApiRequest, response: NextApiResponse) {
+  const { id } = request.query;
+
+  try {
+    const reviews = await getReviewsByMovie(id as string);
+    response.status(200).json({ reviews });
+  } catch (error) {
+    console.error("Failed to fetch reviews:", error);
+    response.status(500).json({ error: "Failed to fetch reviews" });
+  }
+}

--- a/app/api/reviews/[id]/route.ts
+++ b/app/api/reviews/[id]/route.ts
@@ -1,9 +1,10 @@
 import { getReviewsByMovie } from "@/app/features/review/apis";
+import { NextApiRequest } from "next";
 
 export async function GET(
-  req: Request,
+  req: NextApiRequest, // eslint-disable-line
   { params }: { params: { id: string } },
-) {
+): Promise<Response> {
   const movieId = params.id;
 
   const reviews = await getReviewsByMovie(movieId);

--- a/app/api/reviews/[id]/route.ts
+++ b/app/api/reviews/[id]/route.ts
@@ -1,14 +1,12 @@
-import { NextApiRequest, NextApiResponse } from "next";
 import { getReviewsByMovie } from "@/app/features/review/apis";
 
-export async function GET(request: NextApiRequest, response: NextApiResponse) {
-  const { id } = request.query;
+export async function GET(
+  req: Request,
+  { params }: { params: { id: string } },
+) {
+  const movieId = params.id;
 
-  try {
-    const reviews = await getReviewsByMovie(id as string);
-    response.status(200).json({ reviews });
-  } catch (error) {
-    console.error("Failed to fetch reviews:", error);
-    response.status(500).json({ error: "Failed to fetch reviews" });
-  }
+  const reviews = await getReviewsByMovie(movieId);
+
+  return Response.json({ reviews });
 }

--- a/app/api/reviews/[id]/route.ts
+++ b/app/api/reviews/[id]/route.ts
@@ -1,8 +1,8 @@
 import { getReviewsByMovie } from "@/app/features/review/apis";
-import { NextApiRequest } from "next";
+import { NextRequest } from "next/server";
 
 export async function GET(
-  req: NextApiRequest, // eslint-disable-line
+  req: NextRequest, // eslint-disable-line
   { params }: { params: { id: string } },
 ): Promise<Response> {
   const movieId = params.id;

--- a/app/features/review/components/detail-review-card.tsx
+++ b/app/features/review/components/detail-review-card.tsx
@@ -43,8 +43,8 @@ export const DetailReviewCard = ({
 
           <p className="body3 text-gray-500">
             {updatedAt
-              ? `${updatedAt.toLocaleDateString()} (수정됨)`
-              : `${createdAt.toLocaleDateString()}`}
+              ? `${new Date(updatedAt).toLocaleDateString()} (수정됨)`
+              : `${new Date(createdAt).toLocaleDateString()}`}
           </p>
         </Flex>
 

--- a/app/features/review/components/detail-review-dialog.tsx
+++ b/app/features/review/components/detail-review-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Suspense, useState, useEffect } from "react";
 import { useParams } from "next/navigation";
+import { useState, useEffect } from "react";
 
 import { DetailReviewList } from "./detail-review-list";
 
@@ -14,7 +14,9 @@ import {
   Flex,
 } from "@/app/shared/components/ui";
 import { ReviewCardSkeleton } from "./review-card-skeleton";
-import { GetAllReviews, getReviewsByMovie } from "../apis";
+
+import { fetchAPI } from "@/app/shared/apis";
+import { GetAllReviews } from "../apis";
 
 interface DetailReviewDialogProps {
   isOpen: boolean;
@@ -28,13 +30,16 @@ export const DetailReviewDialog = ({
   const params = useParams<{ id: string }>();
 
   const [reviews, setReviews] = useState<GetAllReviews[]>([]);
+  const [isFetching, setIsFetching] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
       const fetchReviews = async () => {
-        const response = await getReviewsByMovie(params.id);
+        setIsFetching(true);
+        const response = await fetchAPI.get(`/api/reviews/${params.id}`);
 
-        setReviews(response);
+        setReviews(response.reviews);
+        setIsFetching(false);
       };
 
       fetchReviews();
@@ -52,17 +57,15 @@ export const DetailReviewDialog = ({
           코멘트가 있습니다.
         </DialogDescription>
 
-        <Suspense
-          fallback={
-            <Flex direction="column" className="gap-4">
-              {Array.from({ length: reviews.length }).map((_, index) => (
-                <ReviewCardSkeleton key={index} />
-              ))}
-            </Flex>
-          }
-        >
+        {isFetching ? (
+          <Flex direction="column" className="gap-4">
+            {Array.from({ length: reviews.length }).map((_, index) => (
+              <ReviewCardSkeleton key={index} />
+            ))}
+          </Flex>
+        ) : (
           <DetailReviewList reviews={reviews} />
-        </Suspense>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/app/shared/apis/fetch.ts
+++ b/app/shared/apis/fetch.ts
@@ -8,6 +8,13 @@ export const API_VARS = {
   YOUTUBE_API_KEY: process.env.YOUTUBE_API_KEY as string,
 } as const;
 
+export const fetchAPI = request.create({
+  baseURL: API_VARS.BASE_URL,
+  headers: {
+    Accept: "application/json",
+  },
+});
+
 export const fetchTMDB = request.create({
   baseURL: API_VARS.TMDB_API_URL,
   headers: {

--- a/app/shared/components/like/like-button.tsx
+++ b/app/shared/components/like/like-button.tsx
@@ -14,7 +14,7 @@ interface LikeButtonProps {
   className?: string;
 }
 
-export const LikeButton = async ({
+export const LikeButton = ({
   id,
   movieId,
   type,


### PR DESCRIPTION
기존 리뷰 데이터 fetching 함수는 `prisma`로 db에 접근하여 직접 데이터를 꺼내오는 방식이기 때문에 이는 `CSR` 환경에서 호출시 에러가 발생한다.

따라서 리뷰 데이터를 받아오는 `route handler` 를 작성하여 해당 함수를 클라이언트 환경에서 호출 할 수 있도록 수정한다.